### PR TITLE
Support -where and -sys cmd-args to dump system.statement table

### DIFF
--- a/cmd/mo-dump/main.go
+++ b/cmd/mo-dump/main.go
@@ -52,6 +52,7 @@ type Options struct {
 	csvFieldDelimiterStr string
 	enableEscape         bool
 	where                string
+	sysAccount           bool // used in getDatabaseType, getTables
 }
 
 func (t *Tables) String() string {
@@ -108,6 +109,7 @@ func main() {
 	flag.BoolVar(&opt.noData, "no-data", defaultNoData, "dump database and table definitions only without data (default false)")
 	flag.BoolVar(&opt.enableEscape, "enable-escape", defaultEnableEscape, "enable escape characters in csv output")
 	flag.StringVar(&opt.where, "where", "", "Dump only selected records. Quotes are mandatory.")
+	flag.BoolVar(&opt.sysAccount, "sys", false, "Dump system table from 'sys' account, used for check db / table schema.")
 	flag.Parse()
 
 	flag.Usage = usage
@@ -209,7 +211,7 @@ func (opt *Options) dumpData(ctx context.Context) error {
 
 	for _, db := range opt.dbs {
 		var dbStruct Db
-		dbStruct, err = getDatabaseType(ctx, db)
+		dbStruct, err = getDatabaseType(ctx, db, opt.sysAccount)
 		if err != nil {
 			return err
 		}
@@ -237,7 +239,7 @@ func (opt *Options) dumpData(ctx context.Context) error {
 				return err
 			}
 		} else {
-			opt.tables, err = getTables(ctx, db, opt.tables)
+			opt.tables, err = getTables(ctx, db, opt.tables, opt.sysAccount)
 			if err != nil {
 				return err
 			}
@@ -399,8 +401,11 @@ func showCreateTable(createSql string, withNextLine bool) {
 	}
 	fmt.Printf("%s%s\n", createSql, suffix)
 }
-func getDatabaseType(ctx context.Context, db string) (Db, error) {
+func getDatabaseType(ctx context.Context, db string, isSys bool) (Db, error) {
 	sql := "select datname, dat_type from mo_catalog.mo_database where datname = '" + db + "'"
+	if isSys {
+		sql += " and account_id = 0"
+	}
 	r, err := conn.Query(sql)
 	if err != nil {
 		return Db{}, err
@@ -422,8 +427,11 @@ func getDatabaseType(ctx context.Context, db string) (Db, error) {
 	return dbs[0], nil
 }
 
-func getTables(ctx context.Context, db string, tables Tables) (Tables, error) {
+func getTables(ctx context.Context, db string, tables Tables, isSys bool) (Tables, error) {
 	sql := "select relname,relkind from mo_catalog.mo_tables where reldatabase = '" + db + "'"
+	if isSys {
+		sql += " and account_id = 0"
+	}
 	tableNames := make(map[string]bool, len(tables))
 	if len(tables) > 0 {
 		sql += " and relname in ("


### PR DESCRIPTION
changes:
1. add `-where=#` option, helps to dump selected data in tables.
2. add `-sys` option, helps to dump table belong to sys account.
